### PR TITLE
Allow multiple users of IPC channel and make options easier to use

### DIFF
--- a/forked.js
+++ b/forked.js
@@ -5,6 +5,7 @@ process.argv.splice(2, 1);
 
 
 function send(message, retries = 0) {
+    message = { ...message, forkRequireMessage: true };
     try {
         process.send(message)
     } catch (err) {
@@ -18,6 +19,7 @@ function send(message, retries = 0) {
 try {
     let forkedModule = require(file);
     process.on('message', async message => {
+        if (message.forkRequireMessage !== true) return;
         try {
             if (message.prop) {
                 if (!forkedModule[message.prop]) {

--- a/index.js
+++ b/index.js
@@ -88,14 +88,16 @@ function send(process, message, retries = 0) {
  * @param {object} [options]    A set of options that will determine how the child process is forked.
  * @returns {Proxy<Module>}     The proxy module that will forward all calls to the child process module
  */
-module.exports = (file, options = {
-    args: getProcessArgs(),
-    env: process.env,
-    cwd: process.cwd(),
-    execArgv: process.execArgv,
-    execPath: process.execPath,
-    fixStack: true
-}) => {
+module.exports = (file, options = {}) => {
+    const defaultOptions = {
+        args: getProcessArgs(),
+        env: process.env,
+        cwd: process.cwd(),
+        execArgv: process.execArgv,
+        execPath: process.execPath,
+        fixStack: true
+    };
+    options = { ...defaultOptions, ...options };
     let orig = Error.prepareStackTrace;
     Error.prepareStackTrace = (_, stack) => stack;
     let stack = new Error().stack;

--- a/index.js
+++ b/index.js
@@ -95,7 +95,8 @@ module.exports = (file, options = {}) => {
         cwd: process.cwd(),
         execArgv: process.execArgv,
         execPath: process.execPath,
-        fixStack: true
+        fixStack: true,
+        stdio: [ "inherit", "inherit", "inherit", "ipc" ]
     };
     options = { ...defaultOptions, ...options };
     let orig = Error.prepareStackTrace;
@@ -110,7 +111,8 @@ module.exports = (file, options = {}) => {
         env: options.env,
         cwd: options.cwd,
         execArgv: options.execArgv,
-        execPath: options.execPath
+        execPath: options.execPath,
+        stdio: options.stdio
     });
     let source = new Error();
     const handler = message => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fork-require",
-  "version": "1.0.9",
+  "version": "1.0.9-unb1",
   "description": "Allows to \"require\" a file, while forking it into a child process.",
   "author": "Ravi Gairola <mallox@pyxzl.net>",
   "homepage": "https://github.com/mallocator/fork-require",


### PR DESCRIPTION
There are 3 commits:

1. Distinguish fork-require's messages on the IPC channel by tagging them with an extra property. This ensures that if there are other users of the parent-child IPC channel, fork-require does not pay attention to those messages, nor does it prematurely stop listening for its own messages.

2. *Breaking change*: Allow the options to fork to be overridden from defaults individually. Previously, if you wanted to change any one of the options from the defaults, you had to fully copy the code that creates fork's default options, then modify the one you wanted to override, then pass in that completed options object. This change allows you to specify only those options you wish to override in the options object and fork will use the defaults for all the rest of the options.

3. Add new option: stdio. This option is then passed directly into child_process.fork's stdio option. The default setting for this option is the same as the default for child_process.fork.
